### PR TITLE
fix bug where not all keys would press immediately

### DIFF
--- a/usb-password-tools-0.01.ino
+++ b/usb-password-tools-0.01.ino
@@ -4,22 +4,18 @@
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include <Keyboard.h>
-//#include <Rotary.h>
-//#include <Encoder.h>
+
 
 #define SCREEN_ADDRESS 0x3D
 #define SCREEN_WIDTH 128  // OLED display width, in pixels
 #define SCREEN_HEIGHT 64  // OLED display height, in pixels
-
-//const int encButton = A0;
-//const int encButton2 = A1;
 
 
 const int keyDelay = 200;
 const int upButtonPin = 14;    // Pin for the "Up" button
 const int downButtonPin = 9;   // Pin for the "Down" button
 const int sendButtonPin = 16;  // Pin for the "Send" button
-
+int i = 0;
 
 //const int numStrings = 4;  // Number of strings in the array
 //String displayText = "Select Password: ";
@@ -31,15 +27,15 @@ struct KeyDescription {
 };
 
 KeyDescription keyDescriptions[] = {
-  { "1 wxyz", "1qaz1qaz000033333" },
-  { "2 username5", "dUH8J2F012GMA1I8kx@EFkbmMaaa036545VDxSaEbwTYVxwrVEjQbeSI7skSwBE6sK" },
-  { "3 ssh", "2345234525636734652343563635emfjfjdjkdjGRGETHGSHdgh" },
-  { "4 sudo", "1qazedwdwdzzeedw1qaz" },
-  { "5 user1", "L1QmrPdewdwdewq7CE2u2gjwZ8m8pvRnXjTMZJpUfcjyLTApd21fnstgbZ8h" },
-  { "6 gmail", "1qazdewdwd1qaz" },
-  { "7", "1qazwfewwwffw1qaz" },
+  { "1", "1qaz1qaz0000" },
+  { "2", "dUH8J2F012GMA1I8kx@EFkbmM036545VDxSaEbwTYVxwrVEjQbeSI7skSwBE6sK" },
+  { "3", "2345234525636734652343563635emfjfjdjkdjGRGETHGSHdgh" },
+  { "4 old sudo", "1qaz1qaz" },
+  { "5 user1", "L1QmrPq7CE2u2gjwZ8m8pvRnXjTMZJpUfcjyLTApd21fnstgbZ8h" },
+  { "6 mac", "1qaz1qaz" },
+  { "7", "1qaz1qaz" },
   { "8", "0000011111222223333344444555556666677777888889999900000" },
-  { "9", "11111111fefeefefefratestringofwordsfromdictionary..00000000" }
+  { "9", "11111111111..generatestringofwordsfromdictionary..00000000" }
 
 };
 
@@ -73,7 +69,7 @@ void setup() {
   display.clearDisplay();
   display.setTextSize(1);
   display.setTextColor(SSD1306_WHITE);
-  Keyboard.begin();
+  //Keyboard.begin();
 
 }
  
@@ -108,6 +104,7 @@ void setup() {
     display.setCursor(1, 1);
     display.println(displayText);
     display.println(keyDescriptions[currentIndex].description);
+    display.println(keyDescriptions[currentIndex].keyValue);
     display.display();
 
   }
@@ -115,9 +112,23 @@ void setup() {
 
 
   void sendString(const char* str) {
-    Keyboard.print(str);  // Send the selected string as keyboard presses
-    //  Keyboard.press(KEY_RETURN);
-    //  Keyboard.releaseAll();
+    Keyboard.begin();
+   // bugfix - send one key at a time instead of the entire string
+    int len = strlen(str);
+    for (int i=0; i<len; i++) {
+      Keyboard.write(str[i]);
+      delay(10);
+    }
+
+   // Keyboard.print(str);  // Send the selected string as keyboard presses
+   
+  //  for (i=0; i<100; i++); { //attempted odd fix 
+  //    Mouse.move(-1,0);
+   //   delay(20);
+  //  }
+
+    Keyboard.end();
+  
   }
 
 


### PR DESCRIPTION
Sometimes in Windows 11 pressing the send button would not output the entire password right away, it got stuck but moving my wireless usb mouse would allow it to print the rest. Maybe something to do with buffers? Problem went away in Linux.

Fixed it by sending each key with a small delay instead of the whole password at once.
